### PR TITLE
Bubble up exceptions when no throws is defined

### DIFF
--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -81,9 +81,13 @@ trait Specify {
         } catch (\PHPUnit_Framework_AssertionFailedError $e) {
             if ($throws !== get_class($e)) $result->addFailure(clone($this), $e, $result->time());
         } catch (\Exception $e) {
-            if ($throws and ($throws !== get_class($e))) {
-                $f = new \PHPUnit_Framework_AssertionFailedError("exception '$throws' was expected, but " . get_class($e) . ' was thrown');
-                $result->addFailure(clone($this), $f, $result->time());
+            if ($throws) {
+                if ($throws !== get_class($e)) {
+                    $f = new \PHPUnit_Framework_AssertionFailedError("exception '$throws' was expected, but " . get_class($e) . ' was thrown');
+                    $result->addFailure(clone($this), $f, $result->time());
+                }
+            } else {
+                throw $e;
             }
         }
 

--- a/tests/SpecifyTest.php
+++ b/tests/SpecifyTest.php
@@ -76,6 +76,16 @@ class SpecifyTest extends \PHPUnit_Framework_TestCase {
         }, ['throws' => 'fail']);
     }
 
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testFailWhenUnexpectedExceptionHappens()
+    {
+        $this->specify('i bubble exception up if no throws is defined', function() {
+            throw new RuntimeException;
+        });
+    }
+
     public function testExamples()
     {
         $this->specify('specify may contain examples', function($a, $b) {


### PR DESCRIPTION
Else the test just passed whenever an exception is thrown.
