### PR TITLE
Fix PHP 5.4 compatibility in RoboFile.php

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -27,8 +27,8 @@ class Robofile extends \Robo\Tasks
     }
 
     protected $docs = [
-        'docs/GlobalConfig.md' => \Codeception\Specify\Config::class,
-        'docs/LocalConfig.md' => \Codeception\Specify\ConfigBuilder::class,
+        'docs/GlobalConfig.md' => '\Codeception\Specify\Config',
+        'docs/LocalConfig.md' => '\Codeception\Specify\ConfigBuilder',
     ];
 
     public function docs()


### PR DESCRIPTION
https://github.com/Codeception/Specify/blob/bf7b985cdc096f92bc14e9c8d7845a5bfc0e8e6e/composer.json#L12
Scalar class name resolution via ::class was added in PHP 5.5.