### PR TITLE
Exception message

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ $this->specify('this assertion is failing', function() {
 ?>
 ```
 
+In both cases, you can optionally test the exception message
+
+``` php
+<?php
+
+$this->specify('some exception with a message', function() {
+	throw new NotFoundException("my error message');
+}, ['throws' => ['NotFoundException', 'my error message']]);
+?>
+```
+
 ## Examples
 
 DataProviders alternative. Quite useful for basic data providers.

--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -85,30 +85,54 @@ trait Specify {
 
     private function getSpecifyExpectedException($params)
     {
-        $throws = false;
         if (isset($params['throws'])) {
-            $throws = $params['throws'];
+            $throws = (is_array($params['throws'])) ? $params['throws'][0] : $params['throws'];
+
             if (is_object($throws)) {
                 $throws = get_class($throws);
             }
             if ($throws === 'fail') {
                 $throws = 'PHPUnit_Framework_AssertionFailedError';
             }
+
+            $message = (is_array($params['throws']) && isset($params['throws'][1])) ? $params['throws'][1] : false;
+
+            return [$throws, $message];
         }
-        return $throws;
+
+        return false;
     }
 
     private function specifyExecute($test, $throws = false, $examples = array())
     {
+        $message = false;
+
+        if (is_array($throws)) {
+            $message = $throws[1];
+            $throws = $throws[0];
+        }
+
         $result = $this->getTestResultObject();
         try {
             call_user_func_array($test, $examples);
         } catch (\PHPUnit_Framework_AssertionFailedError $e) {
-            if ($throws !== get_class($e)) $result->addFailure(clone($this), $e, $result->time());
+            if ($throws !== get_class($e)){
+                $result->addFailure(clone($this), $e, $result->time());
+            }
+
+            if ($message !==false && $message !== $e->getMessage()) {
+                $f = new \PHPUnit_Framework_AssertionFailedError("exception message '$message' was expected, but '" . $e->getMessage() . "' was received");
+                $result->addFailure(clone($this), $f, $result->time());
+            }
         } catch (\Exception $e) {
             if ($throws) {
                 if ($throws !== get_class($e)) {
                     $f = new \PHPUnit_Framework_AssertionFailedError("exception '$throws' was expected, but " . get_class($e) . ' was thrown');
+                    $result->addFailure(clone($this), $f, $result->time());
+                }
+
+                if ($message !==false && $message !== $e->getMessage()) {
+                    $f = new \PHPUnit_Framework_AssertionFailedError("exception message '$message' was expected, but '" . $e->getMessage() . "' was received");
                     $result->addFailure(clone($this), $f, $result->time());
                 }
             } else {

--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -108,7 +108,7 @@ trait Specify {
         $message = false;
 
         if (is_array($throws)) {
-            $message = $throws[1];
+            $message = ($throws[1]) ? strtolower($throws[1]) : false;
             $throws = $throws[0];
         }
 
@@ -120,7 +120,7 @@ trait Specify {
                 $result->addFailure(clone($this), $e, $result->time());
             }
 
-            if ($message !==false && $message !== $e->getMessage()) {
+            if ($message !==false && $message !== strtolower($e->getMessage())) {
                 $f = new \PHPUnit_Framework_AssertionFailedError("exception message '$message' was expected, but '" . $e->getMessage() . "' was received");
                 $result->addFailure(clone($this), $f, $result->time());
             }
@@ -131,7 +131,7 @@ trait Specify {
                     $result->addFailure(clone($this), $f, $result->time());
                 }
 
-                if ($message !==false && $message !== $e->getMessage()) {
+                if ($message !==false && $message !== strtolower($e->getMessage())) {
                     $f = new \PHPUnit_Framework_AssertionFailedError("exception message '$message' was expected, but '" . $e->getMessage() . "' was received");
                     $result->addFailure(clone($this), $f, $result->time());
                 }

--- a/tests/SpecifyTest.php
+++ b/tests/SpecifyTest.php
@@ -125,6 +125,10 @@ class SpecifyTest extends \PHPUnit_Framework_TestCase {
         $this->specify('ignores an empty message', function() {
             $this->fail("test message");
         }, ['throws' => ['fail']]);
+
+        $this->specify('mixed case exception messages', function() {
+            throw new RuntimeException("teSt mESSage");
+        }, ['throws' => ['RuntimeException', 'Test MessaGE']]);
     }
 
     /**

--- a/tests/SpecifyTest.php
+++ b/tests/SpecifyTest.php
@@ -16,7 +16,7 @@ class SpecifyTest extends \PHPUnit_Framework_TestCase {
            $this->user->name = 'jon';
            $this->assertEquals('jon', $this->user->name);
         });
-               
+
         $this->assertEquals('davert', $this->user->name);
 
         $this->specify('i can fail here but test goes on', function() {
@@ -57,7 +57,7 @@ class SpecifyTest extends \PHPUnit_Framework_TestCase {
             $this->user = "jon";
         });
         $this->assertEquals('davert', $this->user);
-    }    
+    }
 
     function testMultiAfterCallback()
     {
@@ -104,6 +104,29 @@ class SpecifyTest extends \PHPUnit_Framework_TestCase {
         }, ['throws' => 'fail']);
     }
 
+    public function testExceptionsWithMessages()
+    {
+        $this->specify('user is invalid', function() {
+            throw new Exception("test message");
+        }, ['throws' => ['Exception', 'test message']]);
+
+        $this->specify('user is invalid', function() {
+            throw new RuntimeException("test message");
+        }, ['throws' => ['RuntimeException', 'test message']]);
+
+        $this->specify('user is invalid', function() {
+            throw new RuntimeException("test message");
+        }, ['throws' => [new RuntimeException(), "test message"]]);
+
+        $this->specify('i can handle fails', function() {
+            $this->fail("test message");
+        }, ['throws' => ['fail', 'test message']]);
+
+        $this->specify('ignores an empty message', function() {
+            $this->fail("test message");
+        }, ['throws' => ['fail']]);
+    }
+
     /**
      * @expectedException RuntimeException
      */
@@ -140,7 +163,7 @@ class SpecifyTest extends \PHPUnit_Framework_TestCase {
             $this->assertEquals(2, $this->a->prop->prop);
         });
         $this->assertEquals(1, $this->a->prop->prop);
-        
+
     }
 
     public function testConfiguration()


### PR DESCRIPTION
Referring to #16, this PR makes it possible to *optionally* test the exception message.

Of course, this is only an enhancement, the current api has not changed.

```php
$this->specify('user is invalid', function() {
            throw new RuntimeException("test message");
        }, ['throws' => ["RuntimeException()", "test message"]]);
```

A couple notes
  * Works for all kinds of exceptions
  * Works for all kinds of `throws` parameters (object, string, fail(), etc)
  * Is an invisible change, meaning the user does not have to check for message
  * Passes all tests, adds new tests, and updates documentation.
  * Only added a few lines of code

I am willing to mix this up if needed. We needed this for our team and just thought I'd share it with the world.
