### PR TITLE
[zszucs]add index to failed tests if examples array is used

### DIFF
--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -42,7 +42,8 @@ trait Specify {
         $throws = $this->getSpecifyExpectedException($params);
         $examples = $this->getSpecifyExamples($params);
 
-        foreach ($examples as $example) {
+        foreach ($examples as $idx => $example) {
+            $this->setName($name.' | '.$specification .' | examples index '. $idx);
             // copy current object properties
             $this->specifyCloneProperties($properties);
 


### PR DESCRIPTION
when a test fails and is using the examples array, the error message doesn't say which index failed.  This pr will add it eg
``` Xyz\Controller\SomeControllerTest::shouldNotSave | under these scenarios | examples index 0
Failed asserting that two strings are equal.```
