### PR TITLE
Code quality, fix bug, added chained methods, added new BDD methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .idea
+.phpunit.result.cache
 composer.phar

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         {
             "name": "Michael Bodnarchuk",
             "email": "davert@codeception.com"
+        },
+        {
+            "name": "Gustavo Nieves",
+            "homepage": "https://medium.com/@ganieves"
         }
     ],
     "require": {

--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -21,7 +21,6 @@ trait Specify
             $this->runSpec($thing, $code, $examples);
             return null;
         }
-        TestCase::markTestIncomplete();
         return $this;
     }
 
@@ -38,7 +37,9 @@ trait Specify
     {
         if ($code instanceof Closure) {
             $this->runSpec($specification, $code, $examples);
+            return $this;
         }
+        TestCase::markTestIncomplete();
         return $this;
     }
 
@@ -51,7 +52,9 @@ trait Specify
     {
         if ($code instanceof Closure) {
             $this->runSpec('should ' . $behavior, $code, $examples);
+            return $this;
         }
+        TestCase::markTestIncomplete();
         return $this;
     }
 
@@ -59,7 +62,9 @@ trait Specify
     {
         if ($code instanceof Closure) {
             $this->runSpec('should not ' . $behavior, $code, $examples);
+            return $this;
         }
+        TestCase::markTestIncomplete();
         return $this;
     }
 }

--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -1,224 +1,65 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace Codeception;
 
-use Codeception\Specify\SpecifyTest;
-use Codeception\Specify\ObjectProperty;
-use PHPUnit\Framework\AssertionFailedError;
+use Closure;
+use Codeception\Specify\SpecifyBoostrap;
 use PHPUnit\Framework\TestCase;
 
 trait Specify
 {
-    private $beforeSpecify = array();
-    private $afterSpecify = array();
-
-    /**
-     * @var \DeepCopy\DeepCopy()
-     */
-    private $copier;
-
-    /**
-     * @var SpecifyTest
-     */
-    private $currentSpecifyTest;
-
-    private $specifyName = '';
-
-    /**
-     * @return SpecifyTest
-     */
-    public function getCurrentSpecifyTest()
-    {
-        return $this->currentSpecifyTest;
+    use SpecifyBoostrap {
+        afterSpecify as public;
+        beforeSpecify as public;
+        cleanSpecify as public;
+        getCurrentSpecifyTest as public;
     }
 
-    public function should($specification, \Closure $callable = null, $params = [])
+    public function specify(string $thing, Closure $code = null, $examples = []): ?self
     {
-        $this->specify("should " . $specification, $callable, $params);
-    }
-
-    public function it($specification, \Closure $callable = null, $params = [])
-    {
-        $this->specify($specification, $callable, $params);
-    }
-
-    public function describe($specification, \Closure $callable = null)
-    {
-        $this->specify($specification, $callable);
-    }
-
-    public function specify($specification, \Closure $callable = null, $params = [])
-    {
-        if (!$callable) {
-            return;
+        if ($code instanceof Closure) {
+            $this->runSpec($thing, $code, $examples);
+            return null;
         }
-
-        /** @var $this TestCase  **/
-        if (!$this->copier) {
-            $this->copier = new \DeepCopy\DeepCopy();
-            $this->copier->skipUncloneable();
-        }
-
-        $properties = $this->getSpecifyObjectProperties();
-
-        // prepare for execution
-        $examples = $this->getSpecifyExamples($params);
-        $showExamplesIndex = $examples !== [[]];
-
-        $specifyName = $this->specifyName;
-        $this->specifyName .= ' ' . $specification;
-
-        foreach ($examples as $idx => $example) {
-            $test = new SpecifyTest($callable->bindTo($this));
-            $this->currentSpecifyTest = $test;
-            $test->setName($this->getName() . ' |' . $this->specifyName);
-            $test->setExample($example);
-            if ($showExamplesIndex) {
-                $test->setName($this->getName() . ' |' . $this->specifyName . ' # example ' . $idx);
-            }
-
-            // copy current object properties
-            $this->specifyCloneProperties($properties);
-
-            if (!empty($this->beforeSpecify) && is_array($this->beforeSpecify)) {
-                foreach ($this->beforeSpecify as $closure) {
-                    if ($closure instanceof \Closure) $closure->__invoke();
-                }
-            }
-
-            $test->run($this->getTestResultObject());
-            $this->specifyCheckMockObjects();
-
-            // restore object properties
-            $this->specifyRestoreProperties($properties);
-
-            if (!empty($this->afterSpecify) && is_array($this->afterSpecify)) {
-                foreach ($this->afterSpecify as $closure) {
-                    if ($closure instanceof \Closure) $closure->__invoke();
-                }
-            }
-        }
-
-        // revert specify name
-        $this->specifyName = $specifyName;
+        TestCase::markTestIncomplete();
+        return $this;
     }
 
-    /**
-     * @param $params
-     * @return array
-     * @throws \RuntimeException
-     */
-    private function getSpecifyExamples($params)
+    public function describe(string $feature, Closure $code = null): ?self
     {
-        if (isset($params['examples'])) {
-            if (!is_array($params['examples'])) throw new \RuntimeException("Examples should be an array");
-            return $params['examples'];
+        if ($code instanceof Closure) {
+            $this->runSpec($feature, $code);
+            return null;
         }
-        return [[]];
+        return $this;
     }
 
-    /**
-     * @return \ReflectionClass|null
-     */
-    private function specifyGetPhpUnitReflection()
+    public function it(string $specification, Closure $code = null, $examples = []): self
     {
-        if ($this instanceof \PHPUnit\Framework\TestCase) {
-            return new \ReflectionClass(\PHPUnit\Framework\TestCase::class);
+        if ($code instanceof Closure) {
+            $this->runSpec($specification, $code, $examples);
         }
+        return $this;
     }
 
-    private function specifyCheckMockObjects()
+    public function its(string $specification, Closure $code = null, $examples = []): self
     {
-        if (($phpUnitReflection = $this->specifyGetPhpUnitReflection()) !== null) {
-            $verifyMockObjects = $phpUnitReflection->getMethod('verifyMockObjects');
-            $verifyMockObjects->setAccessible(true);
-            $verifyMockObjects->invoke($this);
-        }
+        return $this->it($specification, $code, $examples);
     }
 
-    function beforeSpecify(\Closure $callable = null)
+    public function should(string $behavior, Closure $code = null, $examples = []): self
     {
-        $this->beforeSpecify[] = $callable->bindTo($this);
+        if ($code instanceof Closure) {
+            $this->runSpec('should ' . $behavior, $code, $examples);
+        }
+        return $this;
     }
 
-    function afterSpecify(\Closure $callable = null)
+    public function shouldNot(string $behavior, Closure $code = null, $examples = []): self
     {
-        $this->afterSpecify[] = $callable->bindTo($this);
-    }
-
-    function cleanSpecify()
-    {
-        $this->beforeSpecify = $this->afterSpecify = array();
-    }
-
-    /**
-     * @param ObjectProperty[] $properties
-     */
-    private function specifyRestoreProperties($properties)
-    {
-        foreach ($properties as $property) {
-            $property->restoreValue();
+        if ($code instanceof Closure) {
+            $this->runSpec('should not ' . $behavior, $code, $examples);
         }
-    }
-
-    /**
-     * @return ObjectProperty[]
-     */
-    private function getSpecifyObjectProperties()
-    {
-        $objectReflection = new \ReflectionObject($this);
-        $properties = $objectReflection->getProperties();
-
-        if (($classProperties = $this->specifyGetClassPrivateProperties()) !== []) {
-            $properties = array_merge($properties, $classProperties);
-        }
-
-        $clonedProperties = [];
-
-        foreach ($properties as $property) {
-            /** @var $property \ReflectionProperty  **/
-            $docBlock = $property->getDocComment();
-            if (!$docBlock) {
-                continue;
-            }
-            if (preg_match('~\*(\s+)?@specify\s?~', $docBlock)) {
-                $property->setAccessible(true);
-                $clonedProperties[] = new ObjectProperty($this, $property);
-            }
-        }
-
-        // isolate mockObjects property from PHPUnit\Framework\TestCase
-        if ($classReflection = $this->specifyGetPhpUnitReflection()) {
-            $property = $classReflection->getProperty('mockObjects');
-            // remove all mock objects inherited from parent scope(s)
-            $clonedProperties[] = new ObjectProperty($this, $property);
-            $property->setValue($this, []);
-        }
-
-        return $clonedProperties;
-    }
-
-    private function specifyGetClassPrivateProperties()
-    {
-        static $properties = [];
-
-        if (!isset($properties[__CLASS__])) {
-            $reflection = new \ReflectionClass(__CLASS__);
-
-            $properties[__CLASS__] = (get_class($this) !== __CLASS__)
-                ? $reflection->getProperties(\ReflectionProperty::IS_PRIVATE) : [];
-        }
-
-        return $properties[__CLASS__];
-    }
-
-    /**
-     * @param ObjectProperty[] $properties
-     */
-    private function specifyCloneProperties($properties)
-    {
-        foreach ($properties as $property) {
-            $propertyValue = $property->getValue();
-            $property->setValue($this->copier->copy($propertyValue));
-        }
+        return $this;
     }
 }

--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -3,12 +3,12 @@
 namespace Codeception;
 
 use Closure;
-use Codeception\Specify\SpecifyBoostrap;
+use Codeception\Specify\SpecifyHooks;
 use PHPUnit\Framework\TestCase;
 
 trait Specify
 {
-    use SpecifyBoostrap {
+    use SpecifyHooks {
         afterSpecify as public;
         beforeSpecify as public;
         cleanSpecify as public;

--- a/src/Codeception/Specify/ObjectProperty.php
+++ b/src/Codeception/Specify/ObjectProperty.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Codeception\Specify;
+
+use ReflectionProperty;
 
 /**
  * Helper for manipulating by an object property.
@@ -14,7 +17,7 @@ class ObjectProperty
     private $owner;
 
     /**
-     * @var \ReflectionProperty|string
+     * @var ReflectionProperty|string
      */
     private $property;
 
@@ -35,8 +38,8 @@ class ObjectProperty
         $this->owner = $owner;
         $this->property = $property;
 
-        if (!($this->property instanceof \ReflectionProperty)) {
-            $this->property = new \ReflectionProperty($owner, $this->property);
+        if (!($this->property instanceof ReflectionProperty)) {
+            $this->property = new ReflectionProperty($owner, $this->property);
         }
 
         $this->property->setAccessible(true);

--- a/src/Codeception/Specify/SpecifyBoostrap.php
+++ b/src/Codeception/Specify/SpecifyBoostrap.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Codeception\Specify;
+
+use Closure;
+use DeepCopy\DeepCopy;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionObject;
+use ReflectionProperty;
+use RuntimeException;
+
+trait SpecifyBoostrap
+{
+    private $afterSpecify = [];
+
+    private $beforeSpecify = [];
+
+    /**
+     * @var DeepCopy
+     */
+    private $copier;
+
+    /**
+     * @var SpecifyTest
+     */
+    private $currentSpecifyTest;
+
+    private $specifyName = '';
+
+    /**
+     * @return SpecifyTest
+     */
+    private function getCurrentSpecifyTest()
+    {
+        return $this->currentSpecifyTest;
+    }
+    /**
+     * @param string $specification
+     * @param Closure|null $callable
+     * @param callable|array $params
+     */
+    private function runSpec($specification, Closure $callable = null, $params = [])
+    {
+        if (!$callable) {
+            return;
+        }
+
+        if (!$this->copier) {
+            $this->copier = new DeepCopy();
+            $this->copier->skipUncloneable();
+        }
+
+        $properties = $this->getSpecifyObjectProperties();
+
+        // prepare for execution
+        $examples = $this->getSpecifyExamples($params);
+        $showExamplesIndex = $examples !== [[]];
+
+        $specifyName = $this->specifyName;
+        $this->specifyName .= ' ' . $specification;
+
+        foreach ($examples as $idx => $example) {
+            $test = new SpecifyTest($callable->bindTo($this));
+            $this->currentSpecifyTest = $test;
+            $test->setName($this->getName() . ' |' . $this->specifyName);
+            $test->setExample($example);
+            if ($showExamplesIndex) {
+                $test->setName($this->getName() . ' |' . $this->specifyName . ' # example ' . $idx);
+            }
+
+            // copy current object properties
+            $this->specifyCloneProperties($properties);
+
+            if (!empty($this->beforeSpecify) && is_array($this->beforeSpecify)) {
+                foreach ($this->beforeSpecify as $closure) {
+                    if ($closure instanceof Closure) $closure->__invoke();
+                }
+            }
+
+            $test->run($this->getTestResultObject());
+            $this->specifyCheckMockObjects();
+
+            // restore object properties
+            $this->specifyRestoreProperties($properties);
+
+            if (!empty($this->afterSpecify) && is_array($this->afterSpecify)) {
+                foreach ($this->afterSpecify as $closure) {
+                    if ($closure instanceof Closure) $closure->__invoke();
+                }
+            }
+        }
+
+        // revert specify name
+        $this->specifyName = $specifyName;
+    }
+
+    /**
+     * @param $params
+     * @return array
+     */
+    private function getSpecifyExamples($params)
+    {
+        if (isset($params['examples'])) {
+            if (!is_array($params['examples'])) {
+                throw new RuntimeException("Examples should be an array");
+            }
+            return $params['examples'];
+        }
+        return [[]];
+    }
+
+    /**
+     * @return ReflectionClass|null
+     */
+    private function specifyGetPhpUnitReflection()
+    {
+        if ($this instanceof TestCase) {
+            return new ReflectionClass(TestCase::class);
+        }
+        return null;
+    }
+
+    private function specifyCheckMockObjects()
+    {
+        if (($phpUnitReflection = $this->specifyGetPhpUnitReflection()) !== null) {
+            try {
+                $verifyMockObjects = $phpUnitReflection->getMethod('verifyMockObjects');
+                $verifyMockObjects->setAccessible(true);
+                $verifyMockObjects->invoke($this);
+            } catch (ReflectionException $e) {
+            }
+        }
+    }
+
+    /**
+     * @param ObjectProperty[] $properties
+     */
+    private function specifyRestoreProperties($properties)
+    {
+        foreach ($properties as $property) {
+            $property->restoreValue();
+        }
+    }
+
+    /**
+     * @return ObjectProperty[]
+     */
+    private function getSpecifyObjectProperties()
+    {
+        $objectReflection = new ReflectionObject($this);
+        $properties = $objectReflection->getProperties();
+
+        if (($classProperties = $this->specifyGetClassPrivateProperties()) !== []) {
+            $properties = array_merge($properties, $classProperties);
+        }
+
+        $clonedProperties = [];
+
+        foreach ($properties as $property) {
+            /** @var ReflectionProperty $property  **/
+            $docBlock = $property->getDocComment();
+            if (!$docBlock) {
+                continue;
+            }
+            if (preg_match('~\*(\s+)?@specify\s?~', $docBlock)) {
+                $property->setAccessible(true);
+                $clonedProperties[] = new ObjectProperty($this, $property);
+            }
+        }
+
+        // isolate mockObjects property from PHPUnit\Framework\TestCase
+        if ($classReflection = $this->specifyGetPhpUnitReflection()) {
+            try {
+                $property = $classReflection->getProperty('mockObjects');
+                // remove all mock objects inherited from parent scope(s)
+                $clonedProperties[] = new ObjectProperty($this, $property);
+                $property->setValue($this, []);
+            } catch (ReflectionException $e) {
+            }
+        }
+
+        return $clonedProperties;
+    }
+
+    private function specifyGetClassPrivateProperties()
+    {
+        static $properties = [];
+
+        if (!isset($properties[__CLASS__])) {
+            $reflection = new ReflectionClass(__CLASS__);
+
+            $properties[__CLASS__] = (get_class($this) !== __CLASS__)
+                ? $reflection->getProperties(ReflectionProperty::IS_PRIVATE) : [];
+        }
+
+        return $properties[__CLASS__];
+    }
+
+    /**
+     * @param ObjectProperty[] $properties
+     */
+    private function specifyCloneProperties($properties)
+    {
+        foreach ($properties as $property) {
+            $propertyValue = $property->getValue();
+            $property->setValue($this->copier->copy($propertyValue));
+        }
+    }
+
+    private function beforeSpecify(Closure $callable = null)
+    {
+        $this->beforeSpecify[] = $callable->bindTo($this);
+    }
+
+    private function afterSpecify(Closure $callable = null)
+    {
+        $this->afterSpecify[] = $callable->bindTo($this);
+    }
+
+    private function cleanSpecify()
+    {
+        $this->afterSpecify = [];
+        $this->beforeSpecify = [];
+    }
+}

--- a/src/Codeception/Specify/SpecifyHooks.php
+++ b/src/Codeception/Specify/SpecifyHooks.php
@@ -11,7 +11,7 @@ use ReflectionObject;
 use ReflectionProperty;
 use RuntimeException;
 
-trait SpecifyBoostrap
+trait SpecifyHooks
 {
     private $afterSpecify = [];
 

--- a/src/Codeception/Specify/SpecifyTest.php
+++ b/src/Codeception/Specify/SpecifyTest.php
@@ -4,10 +4,11 @@ namespace Codeception\Specify;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\SelfDescribing;
+use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestResult;
 use SebastianBergmann\Exporter\Exporter;
 
-class SpecifyTest implements \PHPUnit\Framework\Test, SelfDescribing
+class SpecifyTest implements Test, SelfDescribing
 {
     protected $name;
 
@@ -59,11 +60,11 @@ class SpecifyTest implements \PHPUnit\Framework\Test, SelfDescribing
     /**
      * Runs a test and collects its result in a TestResult instance.
      *
-     * @param TestResult $result
+     * @param TestResult|null $result
      *
      * @return TestResult
      */
-    public function run(TestResult $result = null) : \PHPUnit\Framework\TestResult
+    public function run(TestResult $result = null): TestResult
     {
         try {
             call_user_func_array($this->test, $this->example);

--- a/tests/ObjectPropertyTest.php
+++ b/tests/ObjectPropertyTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class ObjectPropertyTest extends \SpecifyUnitTest
+use Codeception\Specify\ObjectProperty;
+
+class ObjectPropertyTest extends SpecifyUnitTest
 {
     private $private = 'private';
 
@@ -8,17 +10,17 @@ class ObjectPropertyTest extends \SpecifyUnitTest
     {
         $this->prop = 'test';
 
-        $prop = new \Codeception\Specify\ObjectProperty($this, 'prop');
+        $prop = new ObjectProperty($this, 'prop');
 
         $this->assertEquals('prop', $prop->getName());
         $this->assertEquals('test', $prop->getValue());
 
-        $prop = new \Codeception\Specify\ObjectProperty($this, 'private');
+        $prop = new ObjectProperty($this, 'private');
 
         $this->assertEquals('private', $prop->getName());
         $this->assertEquals('private', $prop->getValue());
 
-        $prop = new \Codeception\Specify\ObjectProperty(
+        $prop = new ObjectProperty(
             $this, new ReflectionProperty($this, 'private')
         );
 
@@ -30,7 +32,7 @@ class ObjectPropertyTest extends \SpecifyUnitTest
     {
         $this->prop = 'test';
 
-        $prop = new \Codeception\Specify\ObjectProperty($this, 'prop');
+        $prop = new ObjectProperty($this, 'prop');
         $prop->setValue('another value');
 
         $this->assertEquals('another value', $this->prop);
@@ -39,7 +41,7 @@ class ObjectPropertyTest extends \SpecifyUnitTest
 
         $this->assertEquals('test', $this->prop);
 
-        $prop = new \Codeception\Specify\ObjectProperty($this, 'private');
+        $prop = new ObjectProperty($this, 'private');
         $prop->setValue('another private value');
 
         $this->assertEquals('another private value', $this->private);
@@ -48,7 +50,7 @@ class ObjectPropertyTest extends \SpecifyUnitTest
 
         $this->assertEquals('private', $this->private);
 
-        $prop = new \Codeception\Specify\ObjectProperty($this, 'prop', 'testing');
+        $prop = new ObjectProperty($this, 'prop', 'testing');
 
         $this->assertEquals('test', $prop->getValue());
 

--- a/tests/SpecifyTest.php
+++ b/tests/SpecifyTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class SpecifyTest extends \SpecifyUnitTest
+use PHPUnit\Framework\IncompleteTestError;
+
+class SpecifyTest extends SpecifyUnitTest
 {
     /**
      * @specify
@@ -37,7 +39,7 @@ class SpecifyTest extends \SpecifyUnitTest
             $this->specify('i can fail here but test goes on', function() {
                 $this->markTestIncomplete();
             });
-        } catch (\PHPUnit\Framework\IncompleteTestError $e) {
+        } catch (IncompleteTestError $e) {
             $this->fail("should not be thrown");
         }
         $this->assertTrue(true);

--- a/tests/_support/SpecifyUnitTest.php
+++ b/tests/_support/SpecifyUnitTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class SpecifyUnitTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SpecifyUnitTest extends TestCase
 {
     use Codeception\Specify;
 


### PR DESCRIPTION
fixes #48 .

**Code Quality:**
- [x] Specify public API now lives inside `Specify.php`, and private properties and methods inside `Specify\SpecifyBoostrap.php` for clarity and readability.
- [x] Added validations regarding whether the anonymous function is received as argument, and improved the names of the arguments depending on the called function.

**Once and for all:**
- [x] Enabled the feature described in the documentation that marks a test as incomplete if the _**it/should**_ only receives the description text without any anonymous function ( #48 ).

**Good things, even better:**
- [x] Added _**Fluent Interface**_ support, this allows you to add `it`'s and `should`'s chained to a `specify` or `describe`. In this way, this example code:
```php
    $this->describe("user", function() {
        $this->it("should have a name", function() {
            // do some asserts
        });

        $this->it("should not have long name", function() {
            // do more asserts
        });
    });
```
can now be written like this:
```php
    $this->describe('user')
        ->it('should have a name', function() {
            // do some asserts
        })
        ->shouldNot('have long name', function() {
            // do more asserts
        })
    ;
```
**Specify is smarter:**
- [x] Added alias `its` for `it`, and added `shouldNot` as counterpart of `should`
- [x] Added `.phpunit.result.cache` file to `.gitignore`

**Getting started:**
- As soon as this PR is merged, I will continue to add improvements to the tests and the other files inside the `Codeception/Specify` folder.
- Some changes may require additional documentation, so improving the docs is one of the goals in sight in future commits.

@DavertMik , @Naktibalda I'll pay attention to your comments.
