### PR TITLE
Fix warning for rfc/deprecate-implicitly-nullable-types and Add php version 8.2 ~ 8.4 to strategy matrix 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
 
     steps:
     - name: Checkout code

--- a/src/Codeception/Specify.php
+++ b/src/Codeception/Specify.php
@@ -17,7 +17,7 @@ trait Specify
         getCurrentSpecifyTest as public;
     }
 
-    public function specify(string $thing, Closure $code = null, $examples = []): ?self
+    public function specify(string $thing, ?Closure $code = null, $examples = []): ?self
     {
         if ($code instanceof Closure) {
             $this->runSpec($thing, $code, $examples);
@@ -27,7 +27,7 @@ trait Specify
         return $this;
     }
 
-    public function describe(string $feature, Closure $code = null): ?self
+    public function describe(string $feature, ?Closure $code = null): ?self
     {
         if ($code instanceof Closure) {
             $this->runSpec($feature, $code);
@@ -37,7 +37,7 @@ trait Specify
         return $this;
     }
 
-    public function it(string $specification, Closure $code = null, $examples = []): self
+    public function it(string $specification, ?Closure $code = null, $examples = []): self
     {
         if ($code instanceof Closure) {
             $this->runSpec($specification, $code, $examples);
@@ -48,12 +48,12 @@ trait Specify
         return $this;
     }
 
-    public function its(string $specification, Closure $code = null, $examples = []): self
+    public function its(string $specification, ?Closure $code = null, $examples = []): self
     {
         return $this->it($specification, $code, $examples);
     }
 
-    public function should(string $behavior, Closure $code = null, $examples = []): self
+    public function should(string $behavior, ?Closure $code = null, $examples = []): self
     {
         if ($code instanceof Closure) {
             $this->runSpec('should ' . $behavior, $code, $examples);
@@ -64,7 +64,7 @@ trait Specify
         return $this;
     }
 
-    public function shouldNot(string $behavior, Closure $code = null, $examples = []): self
+    public function shouldNot(string $behavior, ?Closure $code = null, $examples = []): self
     {
         if ($code instanceof Closure) {
             $this->runSpec('should not ' . $behavior, $code, $examples);

--- a/src/Codeception/Specify/SpecifyHooks.php
+++ b/src/Codeception/Specify/SpecifyHooks.php
@@ -35,7 +35,7 @@ trait SpecifyHooks
      * @param Closure|null $callable
      * @param callable|array $params
      */
-    private function runSpec(string $specification, Closure $callable = null, $params = [])
+    private function runSpec(string $specification, ?Closure $callable = null, $params = [])
     {
         if ($callable === null) {
             return;
@@ -204,12 +204,12 @@ trait SpecifyHooks
         }
     }
 
-    private function beforeSpecify(Closure $callable = null)
+    private function beforeSpecify(?Closure $callable = null)
     {
         $this->beforeSpecify[] = $callable->bindTo($this);
     }
 
-    private function afterSpecify(Closure $callable = null)
+    private function afterSpecify(?Closure $callable = null)
     {
         $this->afterSpecify[] = $callable->bindTo($this);
     }

--- a/src/Codeception/Specify/SpecifyTest.php
+++ b/src/Codeception/Specify/SpecifyTest.php
@@ -65,7 +65,7 @@ class SpecifyTest implements Test, SelfDescribing
     /**
      * Runs a test and collects its result in a TestResult instance.
      */
-    public function run(TestResult $result = null): TestResult
+    public function run(?TestResult $result = null): TestResult
     {
         try {
             call_user_func_array($this->test, $this->example);


### PR DESCRIPTION
for https://wiki.php.net/rfc/deprecate-implicitly-nullable-types


### before:
```text
~/work/Specify$ docker run --rm --interactive --tty --volume $PWD:/app --workdir /app php:8.4-cli vendor/bin/phpunit -c ./phpunit.xml

Deprecated: Codeception\Specify::specify(): Implicitly marking parameter $code as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify.php on line 20

Deprecated: Codeception\Specify::describe(): Implicitly marking parameter $code as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify.php on line 30

Deprecated: Codeception\Specify::it(): Implicitly marking parameter $code as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify.php on line 40

Deprecated: Codeception\Specify::its(): Implicitly marking parameter $code as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify.php on line 51

Deprecated: Codeception\Specify::should(): Implicitly marking parameter $code as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify.php on line 56

Deprecated: Codeception\Specify::shouldNot(): Implicitly marking parameter $code as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify.php on line 67

Deprecated: Codeception\Specify\SpecifyHooks::runSpec(): Implicitly marking parameter $callable as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify/SpecifyHooks.php on line 38

Deprecated: Codeception\Specify\SpecifyHooks::beforeSpecify(): Implicitly marking parameter $callable as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify/SpecifyHooks.php on line 207

Deprecated: Codeception\Specify\SpecifyHooks::afterSpecify(): Implicitly marking parameter $callable as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify/SpecifyHooks.php on line 212
PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

..
Deprecated: Codeception\Specify\SpecifyTest::run(): Implicitly marking parameter $result as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Codeception/Specify/SpecifyTest.php on line 68
I...................

Time: 00:00.038, Memory: 8.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 22, Assertions: 67, Incomplete: 1.
```

### after 
```text
~/work/Specify$ docker run --rm --interactive --tty --volume $PWD:/app --workdir /app php:8.4-cli vendor/bin/phpunit -c ./phpunit.xml
PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

..I...................

Time: 00:00.039, Memory: 8.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 22, Assertions: 67, Incomplete: 1.
```